### PR TITLE
fix: carousel import selector

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -74,8 +74,8 @@ function addCarouselItems(doc) {
       return div;
     });
 
-    const imageItemsFromDoc = doc.querySelectorAll('.img-content');
-    let imageItems = imageItemsFromDoc.length ? [...imageItemsFromDoc].slice(1, -1) : [];
+    const imageItemsFromDoc = doc.querySelectorAll('.swiper-slide:not(.swiper-slide-duplicate) .img-content');
+    let imageItems = imageItemsFromDoc.length ? [...imageItemsFromDoc] : [];
     imageItems = imageItems.map((x) => {
       const div = document.createElement('div');
       div.appendChild(WebImporter.DOMUtils.replaceBackgroundByImg(x, document));


### PR DESCRIPTION
* import failed with array-out-of-bounds when JavaScript is disabled
* patching the selector to work with pick images that aren't 'duplicates'

Fixes #47

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/
- After: https://fix-carousel-import--sunstar-engineering--hlxsites.hlx.page/
