### PR TITLE
Added a 'constrain-width' variant of Columns Block

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -1,3 +1,7 @@
+.columns {
+  margin: 2rem 0;
+}
+
 .columns > div {
   display: flex;
   flex-direction: column;
@@ -12,7 +16,9 @@
 }
 
 .columns h6 {
+  color: var(--secondary);
   font-size: var(--heading-font-size-xxxs);
+  margin-top: 2rem;
 }
 
 .columns p.button-container {
@@ -49,7 +55,7 @@
 }
 
 .columns > div > div > h2 {
-  margin: 2rem 0;
+  margin: 1.5rem 0;
 }
 
 .columns > div > div > p {
@@ -57,10 +63,17 @@
 }
 
 .columns > div > div.non-singleton-img {
-  margin: 2rem 1rem;
+  margin: 0 1rem;
+}
+.columns.constrain-width > div > div.columns-img-col {
+  margin: 0 1rem;
 }
 
 @media (min-width: 992px) {
+  .columns {
+    margin-bottom: 7.5rem;
+  }
+
   .columns h2 {
     font-size: var(--heading-font-size-xl);
   }
@@ -79,7 +92,7 @@
   }
 
   .columns > div {
-    align-items: flex-start;
+    align-items: center;
     flex-direction: unset;
     gap: 3rem;
   }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -65,6 +65,7 @@
 .columns > div > div.non-singleton-img {
   margin: 0 1rem;
 }
+
 .columns.constrain-width > div > div.columns-img-col {
   margin: 0 1rem;
 }

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -179,6 +179,9 @@ function createColumnBlockFromSection(document) {
         columnItem.push(column);
       });
       block.push(columnItem);
+      if (section.querySelectorAll('.background-image').length) {
+        block[0][0] += ' (constrain-width)';
+      }
       const table = WebImporter.DOMUtils.createTable(block, document);
       convertBackgroundImgsToForegroundImgs(table, document);
       section.replaceWith(table);


### PR DESCRIPTION
* prevents edge-to-edge fill of column block images on Mobile view
  * updated importer code to generate this variant automatically
  * heuristic used: whenever a 'column block image' was set as
    'background-image' in original site, define a constrained-width
    column
* also added minor styling updates

Part of #48

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/
- After: https://issue-48-column-styling-v2--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/air
- After: https://issue-48-column-styling-v2--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/air
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about
- After: https://issue-48-column-styling-v2--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about

