### PR TITLE
adding styled-para with variant-images block

### DIFF
--- a/blocks/styled-para/styled-para.css
+++ b/blocks/styled-para/styled-para.css
@@ -1,0 +1,77 @@
+.styled-para {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.styled-para h2 {
+  font-size: var(--heading-font-size-m);
+}
+
+.styled-para > div {
+  margin: 1.5rem 0;
+}
+
+.styled-para .styled-para-1-cols {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 0 1rem;
+}
+
+.styled-para .wide {
+  display: none;
+}
+
+.styled-para .narrow {
+  display: block;
+  justify-content: center;
+}
+
+.styled-para a.button.tertiary {
+  background-color: unset;
+  color: var(--tertiary);
+  justify-content: flex-start;
+}
+
+.styled-para a.button.tertiary::after {
+  content: url("../../icons/link.svg");
+  position: relative;
+  top: 0.1rem;
+  left: 0.3rem;
+}
+
+.styled-para .heading > h2 {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.styled-para .content > p {
+  margin: 1.5rem 0;
+}
+
+.styled-para .content > .button-container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 992px) {
+  .styled-para .wide {
+    display: block;
+    justify-content: center;
+  }
+
+  .styled-para h2 {
+    font-size: var(--heading-font-size-xl);
+  }
+
+  .styled-para .narrow {
+    display: none;
+  }
+
+  .styled-para .content {
+    text-align: center;
+    width: 70%;
+  }
+}

--- a/blocks/styled-para/styled-para.js
+++ b/blocks/styled-para/styled-para.js
@@ -1,0 +1,29 @@
+export default async function decorate(block) {
+  [...block.children].forEach((row) => {
+    const colCount = row.children.length;
+    row.classList.add(`styled-para-${colCount}-cols`);
+  });
+
+  block.querySelectorAll('.styled-para-1-cols').forEach((row) => {
+    row.querySelector('p')?.
+        parentElement?.classList.add('content');
+    row.querySelector('h1, h2, h3, h4, h5, h6')?.
+        parentElement?.classList.add('heading');
+  });
+
+  block.querySelectorAll('.styled-para-2-cols').forEach((row) => {
+    const typeHintEl = row.querySelector('div:first-child');
+    const typeHints = typeHintEl?.textContent?.
+        trim()?.toLowerCase()?.
+        split(',')?.map((type) => type.trim());
+    if (typeHints?.length) {
+      row.classList.add(...typeHints);
+      typeHintEl.remove();
+    }
+  });
+
+  block.querySelectorAll('.button-container > .button').forEach((a) => {
+    a.classList.remove('primary', 'secondary', 'tertiary');
+    a.classList.add('tertiary');
+  });
+}

--- a/icons/link.svg
+++ b/icons/link.svg
@@ -1,0 +1,1 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M20 4.5v6a.5.5 0 11-1 0V5.707L7.854 16.854a.5.5 0 01-.708-.708L18.293 5H13.5a.5.5 0 110-1H20v.5zm-3 15v.5H4V7h6.5a.5.5 0 110 1H5v11h11v-5.469a.5.5 0 111 0V19.5z" fill="#007CAD" fill-rule="evenodd"/></svg>


### PR DESCRIPTION
Adds an additional 'styled-para' block that allows for:

* centering the content
* selecting images for different screen-widths

Fix #58

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about
- After: https://58-variant-images-sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about
