### PR TITLE
Add language support to search

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -159,7 +159,7 @@ function decorateBottomNav(nav, placeholders) {
   menuBackBtn.classList.add('menu-back-btn');
   menuBackBtn.innerHTML = `<span class="icon icon-angle-left"></span><a>${placeholders['back-to-menu']}</a>`;
   nav.prepend(menuBackBtn);
-  nav.append(getSearchWidget());
+  nav.append(getSearchWidget(placeholders));
 
   menuBackBtn.addEventListener('click', () => {
     const level1Open = nav.querySelector(':scope .menu-level-1.open');
@@ -199,8 +199,7 @@ export default async function decorate(block) {
   const resp = await fetch(`${navPath}.plain.html`);
 
   if (resp.ok) {
-    // TODO: localize
-    const placeholders = await fetchPlaceholders();
+    const placeholders = await fetchPlaceholders(getLanguage());
     block.innerHTML = '';
     const html = await resp.text();
     const fetchedNav = document.createElement('div');

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -112,16 +112,19 @@ export function addPagingWidget(
   div.appendChild(nav);
 }
 
-function formatSearchResultCount(num, placeholders, term) {
-  if (placeholders.resultstext_postfix) {
-    // This is for languages like Japanese
-    return `「<strong>${term}</strong>」 ${placeholders.resultstext} ${num}${placeholders.resultstext_postfix}`;
+function formatSearchResultCount(num, placeholders, term, lang) {
+  if (lang === 'ja') {
+    return `「<strong>${term}</strong>」 ${placeholders.resultstext_prefix} ${num}${placeholders.resultstext_postfix}`;
   }
-  return `${num} ${placeholders.resultstext} "<strong>${term}</strong>"`;
+  if (lang === 'cn') {
+    return `"<strong>${term}</strong>" ${placeholders.resultstext_prefix} ${num}${placeholders.resultstext_postfix}`;
+  }
+  return `${placeholders.resultstext_prefix ?? ''} ${num} ${placeholders.resultstext_postfix} "<strong>${term}</strong>"`;
 }
 
 async function searchPages(placeholders, term, page) {
-  const sheet = getLanguage() === 'en' ? undefined : `${getLanguage()}-search`;
+  const lang = getLanguage();
+  const sheet = lang === 'en' ? undefined : `${lang}-search`;
 
   const json = await fetchIndex('query-index', sheet);
   fixExcelFilterZeroes(json.data);
@@ -137,7 +140,7 @@ async function searchPages(placeholders, term, page) {
 
   const summary = document.createElement('h3');
   summary.classList.add('search-summary');
-  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term);
+  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term, lang);
   div.appendChild(summary);
 
   const curPage = result.slice(startResult, startResult + resultsPerPage);

--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -1,5 +1,10 @@
-import { fetchIndex, fixExcelFilterZeroes, getSearchWidget } from '../../scripts/scripts.js';
-import { getFormattedDate } from '../../scripts/lib-franklin.js';
+import { fetchPlaceholders, getFormattedDate } from '../../scripts/lib-franklin.js';
+import {
+  fetchIndex,
+  fixExcelFilterZeroes,
+  getLanguage,
+  getSearchWidget,
+} from '../../scripts/scripts.js';
 
 export function getSearchParams(searchParams) {
   let curPage = new URLSearchParams(searchParams).get('pg');
@@ -107,8 +112,18 @@ export function addPagingWidget(
   div.appendChild(nav);
 }
 
-async function searchPages(term, page) {
-  const json = await fetchIndex('query-index');
+function formatSearchResultCount(num, placeholders, term) {
+  if (placeholders.resultstext_postfix) {
+    // This is for languages like Japanese
+    return `「<strong>${term}</strong>」 ${placeholders.resultstext} ${num}${placeholders.resultstext_postfix}`;
+  }
+  return `${num} ${placeholders.resultstext} "<strong>${term}</strong>"`;
+}
+
+async function searchPages(placeholders, term, page) {
+  const sheet = getLanguage() === 'en' ? undefined : `${getLanguage()}-search`;
+
+  const json = await fetchIndex('query-index', sheet);
   fixExcelFilterZeroes(json.data);
 
   const resultsPerPage = 10;
@@ -122,7 +137,7 @@ async function searchPages(term, page) {
 
   const summary = document.createElement('h3');
   summary.classList.add('search-summary');
-  summary.innerHTML = `${result.length} result${result.length === 1 ? '' : 's'} found for "<strong>${term}</strong>"`;
+  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term);
   div.appendChild(summary);
 
   const curPage = result.slice(startResult, startResult + resultsPerPage);
@@ -198,14 +213,22 @@ async function searchPages(term, page) {
  * decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
-export default async function decorate(block, curLocation = window.location) {
+export default async function decorate(
+  block,
+  curLocation = window.location,
+  resetLanguageCache = false,
+) {
   const { searchTerm, curPage } = getSearchParams(curLocation.search);
+  const placeholders = await fetchPlaceholders(getLanguage(
+    curLocation.pathname,
+    resetLanguageCache,
+  ));
 
   block.innerHTML = '';
-  block.append(getSearchWidget(searchTerm, true));
+  block.append(getSearchWidget(placeholders, searchTerm, true));
 
   if (searchTerm) {
-    const results = await searchPages(searchTerm, curPage);
+    const results = await searchPages(placeholders, searchTerm, curPage);
     block.append(...results);
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,11 +32,16 @@ export function getLanguageFromPath(pathname, resetCache = false) {
       language = l;
     }
   }
+
+  if (language === undefined) {
+    language = 'en'; // default to English
+  }
+
   return language;
 }
 
-export function getLanguage() {
-  return getLanguageFromPath(window.location.pathname);
+export function getLanguage(curPath = window.location.pathname, resetCache = false) {
+  return getLanguageFromPath(curPath, resetCache);
 }
 /**
  * Builds hero block and prepends to main in a new section.
@@ -187,40 +192,44 @@ export function fixExcelFilterZeroes(data) {
   });
 }
 
-export async function fetchIndex(indexFile, pageSize = 500) {
+export async function fetchIndex(indexFile, sheet, pageSize = 500) {
+  const idxKey = indexFile.concat(sheet || '');
+
   const handleIndex = async (offset) => {
-    const resp = await fetch(`/${indexFile}.json?limit=${pageSize}&offset=${offset}`);
+    const sheetParam = sheet ? `&sheet=${sheet}` : '';
+
+    const resp = await fetch(`/${indexFile}.json?limit=${pageSize}&offset=${offset}${sheetParam}`);
     const json = await resp.json();
 
     const newIndex = {
       complete: (json.limit + json.offset) === json.total,
       offset: json.offset + pageSize,
       promise: null,
-      data: [...window.index[indexFile].data, ...json.data],
+      data: [...window.index[idxKey].data, ...json.data],
     };
 
     return newIndex;
   };
 
   window.index = window.index || {};
-  window.index[indexFile] = window.index[indexFile] || {
+  window.index[idxKey] = window.index[idxKey] || {
     data: [],
     offset: 0,
     complete: false,
     promise: null,
   };
 
-  if (window.index[indexFile].complete) {
-    return window.index[indexFile];
+  if (window.index[idxKey].complete) {
+    return window.index[idxKey];
   }
 
-  if (window.index[indexFile].promise) {
-    return window.index[indexFile].promise;
+  if (window.index[idxKey].promise) {
+    return window.index[idxKey].promise;
   }
 
-  window.index[indexFile].promise = handleIndex(window.index[indexFile].offset);
-  const newIndex = await (window.index[indexFile].promise);
-  window.index[indexFile] = newIndex;
+  window.index[idxKey].promise = handleIndex(window.index[idxKey].offset);
+  const newIndex = await (window.index[idxKey].promise);
+  window.index[idxKey] = newIndex;
 
   return newIndex;
 }
@@ -252,23 +261,24 @@ export function htmlToElement(html) {
   return div.firstElementChild;
 }
 
-function getSearchWidgetHTML(initialVal, searchbox) {
-  // TODO specify the correct language in the 'lang' input
-  // TODO specify the correct language in the oninvalid property
+function getSearchWidgetHTML(placeholders, initialVal, searchbox, lang) {
+  const langPrefix = lang === 'en' ? '' : `/${lang}`;
   const searchType = searchbox ? 'search' : 'text';
 
   return `
-    <form method="get" class="search" action="/search">
+    <form method="get" class="search" action="${langPrefix}/search">
       <div>
-        <input type="hidden" name="lang" value="en">
-        <input type="${searchType}" name="s" value="${initialVal ?? ''}" class="search-text" placeholder="Search" required="true" oninput="this.setCustomValidity('')" oninvalid="this.setCustomValidity('The Search field cannot be empty')">
+        <input type="${searchType}" name="s" value="${initialVal ?? ''}" class="search-text"
+          placeholder="${placeholders.searchtext}" required="true" oninput="this.setCustomValidity('')"
+          oninvalid="this.setCustomValidity('${placeholders.emptysearchtext}')">
         <button class="icon search-icon" aria-label="Search"></button>
       </div>
     </form>`;
 }
 
-export function getSearchWidget(initialVal, searchbox) {
-  return htmlToElement(getSearchWidgetHTML(initialVal, searchbox));
+export function getSearchWidget(placeholders, initialVal, searchbox, lang = getLanguage()) {
+  const widget = getSearchWidgetHTML(placeholders, initialVal, searchbox, lang);
+  return htmlToElement(widget);
 }
 
 /*

--- a/test/blocks/search-results/search-results.test.js
+++ b/test/blocks/search-results/search-results.test.js
@@ -158,6 +158,16 @@ describe('Search Results', () => {
   });
 
   it('Page generation', async () => {
+    const placeholders = {
+      resultstext: 'matches for',
+    };
+    window.placeholders = {
+      'translation-loaded': {},
+      translation: {
+        en: placeholders,
+      },
+    };
+
     const queryIndex = '/query-index.json';
     const mf = sinon.stub(window, 'fetch');
     mf.callsFake((v) => {
@@ -198,7 +208,7 @@ describe('Search Results', () => {
     const searchSummary = block.children[1];
     expect(searchSummary.nodeName).to.equal('H3');
     expect(searchSummary.classList.toString()).to.equal('search-summary');
-    expect(searchSummary.innerHTML).to.equal('2 results found for "<strong>tex</strong>"');
+    expect(searchSummary.innerHTML).to.equal('2 matches for "<strong>tex</strong>"');
 
     const res1 = block.children[2];
     expect(res1.nodeName).to.equal('DIV');
@@ -219,6 +229,74 @@ describe('Search Results', () => {
     expect(res2h3a.href.endsWith('/news/c/')).to.be.true;
 
     const pageWidget = block.children[4];
+    expect(pageWidget.className.toString()).to.equal('pagination');
+  });
+
+  it('Page generation alt language', async () => {
+    const placeholders = {
+      resultstext: 'の検索結果',
+      resultstext_postfix: '件',
+      searchtext: '検索',
+    };
+    window.placeholders = {
+      'translation-loaded': {},
+      translation: {
+        ja: placeholders,
+      },
+    };
+
+    const queryIndex = '/query-index.json';
+    const mf = sinon.stub(window, 'fetch');
+    mf.callsFake((v) => {
+      if (v.startsWith(queryIndex)) {
+        return {
+          ok: true,
+          json: () => ({
+            data: [
+              { path: '/ja/news/a/', title: 'a text', lastModified: 1685443971 },
+              { path: '/ja/news/b/', title: 'some b', lastModified: 1685443972 },
+              { path: '/ja/news/c/', title: 'c text', lastModified: 1685443973 },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: false, json: () => ({ data: [] }), text: () => '',
+      };
+    });
+
+    const block = document.querySelector('.search-results');
+    const loc = {
+      search: '?s=a',
+      pathname: '/ja/search',
+    };
+
+    try {
+      await scripts.default(block, loc, true);
+    } finally {
+      mf.restore();
+    }
+
+    const searchForm = block.children[0];
+    expect(searchForm.nodeName).to.equal('FORM');
+    expect(searchForm.classList.toString()).to.equal('search');
+
+    const searchSummary = block.children[1];
+    expect(searchSummary.nodeName).to.equal('H3');
+    expect(searchSummary.classList.toString()).to.equal('search-summary');
+    expect(searchSummary.innerHTML).to.equal('「<strong>a</strong>」 の検索結果 1件');
+
+    const res1 = block.children[2];
+    expect(res1.nodeName).to.equal('DIV');
+    expect(res1.classList.toString()).to.equal('search-result');
+    const res1h3 = res1.children[0];
+    expect(res1h3.nodeName).to.equal('H3');
+    const res1h3a = res1h3.children[0];
+    expect(res1h3a.nodeName).to.equal('A');
+    expect(res1h3a.href.endsWith('/ja/news/a/')).to.be.true;
+
+    const pageWidget = block.children[3];
     expect(pageWidget.className.toString()).to.equal('pagination');
   });
 });

--- a/test/blocks/search-results/search-results.test.js
+++ b/test/blocks/search-results/search-results.test.js
@@ -159,7 +159,7 @@ describe('Search Results', () => {
 
   it('Page generation', async () => {
     const placeholders = {
-      resultstext: 'matches for',
+      resultstext_postfix: 'matches for',
     };
     window.placeholders = {
       'translation-loaded': {},
@@ -208,7 +208,7 @@ describe('Search Results', () => {
     const searchSummary = block.children[1];
     expect(searchSummary.nodeName).to.equal('H3');
     expect(searchSummary.classList.toString()).to.equal('search-summary');
-    expect(searchSummary.innerHTML).to.equal('2 matches for "<strong>tex</strong>"');
+    expect(searchSummary.innerHTML.trim()).to.equal('2 matches for "<strong>tex</strong>"');
 
     const res1 = block.children[2];
     expect(res1.nodeName).to.equal('DIV');
@@ -234,7 +234,7 @@ describe('Search Results', () => {
 
   it('Page generation alt language', async () => {
     const placeholders = {
-      resultstext: 'の検索結果',
+      resultstext_prefix: 'の検索結果',
       resultstext_postfix: '件',
       searchtext: '検索',
     };

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -24,17 +24,26 @@ describe('Scripts', () => {
   });
 
   it('Creates the Search widget without value', () => {
-    const form = scripts.getSearchWidget();
-    expect(form.action.endsWith('/search')).to.be.true;
+    const placeholders = {
+      emptysearchtext: 'Cannot be empty',
+      searchtext: 'MySearch',
+    };
+
+    const form = scripts.getSearchWidget(placeholders);
+    expect(new URL(form.action).pathname).to.equal('/search');
 
     const div = form.children[0];
     const it = div.getElementsByClassName('search-text');
     expect(it[0].type).to.equal('text');
     expect(it[0].value).to.equal('');
+    expect(it[0].placeholder).to.equal('MySearch');
+    expect(it[0].oninvalid.toString().replace(/(\r\n|\n|\r)/gm, ''))
+      .to.equal('function oninvalid(event) {this.setCustomValidity(\'Cannot be empty\')}');
   });
 
   it('Creates the Search widget with value', () => {
-    const form = scripts.getSearchWidget('hello', true);
+    const form = scripts.getSearchWidget({}, 'hello', true, 'de');
+    expect(new URL(form.action).pathname).to.equal('/de/search');
 
     const div = form.children[0];
     const it = div.getElementsByClassName('search-text');


### PR DESCRIPTION
Fixes #40

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/de/search?s=Schweißerei
- After: 
  - German Search: https://issue-40c--sunstar-engineering--hlxsites.hlx.page/de/search?s=Schweißerei
  - Japanese Search: https://issue-40c--sunstar-engineering--hlxsites.hlx.page/ja/search?s=a

Thanks to @JiangLong2019 for the Japanese translations and Paolo Mottadelli for the Italian ones, both of which are not in the original site.
