### PR TITLE
Include pagename in search query and result headers

### DIFF
--- a/blocks/search-results/search-results.js
+++ b/blocks/search-results/search-results.js
@@ -123,8 +123,7 @@ function formatSearchResultCount(num, placeholders, term, lang) {
 }
 
 async function searchPages(placeholders, term, page) {
-  const lang = getLanguage();
-  const sheet = lang === 'en' ? undefined : `${lang}-search`;
+  const sheet = `${getLanguage()}-search`;
 
   const json = await fetchIndex('query-index', sheet);
   fixExcelFilterZeroes(json.data);
@@ -133,14 +132,14 @@ async function searchPages(placeholders, term, page) {
   const startResult = page * resultsPerPage;
 
   const result = json.data
-    .filter((entry) => `${entry.description} ${entry.title}`.toLowerCase()
+    .filter((entry) => `${entry.description} ${entry.pagename} ${entry.breadcrumbtitle} ${entry.title}`.toLowerCase()
       .includes(term.toLowerCase()));
 
   const div = document.createElement('div');
 
   const summary = document.createElement('h3');
   summary.classList.add('search-summary');
-  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term, lang);
+  summary.innerHTML = formatSearchResultCount(result.length, placeholders, term, getLanguage());
   div.appendChild(summary);
 
   const curPage = result.slice(startResult, startResult + resultsPerPage);
@@ -150,7 +149,8 @@ async function searchPages(placeholders, term, page) {
     res.classList.add('search-result');
     const header = document.createElement('h3');
     const link = document.createElement('a');
-    setResultValue(link, line.title, term);
+    const searchTitle = line.pagename || line.breadcrumbtitle || line.title;
+    setResultValue(link, searchTitle, term);
     link.href = line.path;
     const path = line.path || '';
     const parentPath = path && path.lastIndexOf('/') > -1 ? path.slice(0, path.lastIndexOf('/')) : '';

--- a/test/blocks/search-results/search-results.test.js
+++ b/test/blocks/search-results/search-results.test.js
@@ -168,17 +168,18 @@ describe('Search Results', () => {
       },
     };
 
-    const queryIndex = '/query-index.json';
+    const queryIndex = /query-index.json\\?(.*)&sheet=en-search/;
     const mf = sinon.stub(window, 'fetch');
     mf.callsFake((v) => {
-      if (v.startsWith(queryIndex)) {
+      if (queryIndex.test(v)) {
         return {
           ok: true,
           json: () => ({
             data: [
-              { path: '/news/a/', title: 'a text', lastModified: 1685443971 },
+              { path: '/news/a/', pagename: 'a text', lastModified: 1685443971 },
               { path: '/news/b/', title: 'some b', lastModified: 1685443972 },
-              { path: '/news/c/', title: 'c text', lastModified: 1685443973 },
+              { path: '/news/c/', breadcrumbtitle: 'c text', lastModified: 1685443973 },
+              { path: '/news/d/', description: 'text of d', lastModified: 1685443974 },
             ],
           }),
         };
@@ -208,7 +209,7 @@ describe('Search Results', () => {
     const searchSummary = block.children[1];
     expect(searchSummary.nodeName).to.equal('H3');
     expect(searchSummary.classList.toString()).to.equal('search-summary');
-    expect(searchSummary.innerHTML.trim()).to.equal('2 matches for "<strong>tex</strong>"');
+    expect(searchSummary.innerHTML.trim()).to.equal('3 matches for "<strong>tex</strong>"');
 
     const res1 = block.children[2];
     expect(res1.nodeName).to.equal('DIV');
@@ -228,7 +229,16 @@ describe('Search Results', () => {
     expect(res2h3a.nodeName).to.equal('A');
     expect(res2h3a.href.endsWith('/news/c/')).to.be.true;
 
-    const pageWidget = block.children[4];
+    const res3 = block.children[4];
+    expect(res3.nodeName).to.equal('DIV');
+    expect(res3.classList.toString()).to.equal('search-result');
+    const res3h3 = res3.children[0];
+    expect(res3h3.nodeName).to.equal('H3');
+    const res3h3a = res3h3.children[0];
+    expect(res3h3a.nodeName).to.equal('A');
+    expect(res3h3a.href.endsWith('/news/d/')).to.be.true;
+
+    const pageWidget = block.children[5];
     expect(pageWidget.className.toString()).to.equal('pagination');
   });
 
@@ -245,10 +255,10 @@ describe('Search Results', () => {
       },
     };
 
-    const queryIndex = '/query-index.json';
+    const queryIndex = /query-index.json\\?(.*)&sheet=ja-search/;
     const mf = sinon.stub(window, 'fetch');
     mf.callsFake((v) => {
-      if (v.startsWith(queryIndex)) {
+      if (queryIndex.test(v)) {
         return {
           ok: true,
           json: () => ({


### PR DESCRIPTION
Additionally breadcrumbtitle is included.
Also changed the url where the English-language search index is fetched from: now at query-index.json?sheet=en-search.

Fix #141

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/search?s=adhesives
- After: https://issue-141--sunstar-engineering--hlxsites.hlx.page/search?s=adhesives

