### PR TITLE
Update cards block for nolink view on detail page

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -12,12 +12,12 @@
 }
 
 main .block.cards {
-    margin: 0 auto 60px;
-    padding-left: 16px;
-    padding-right: 16px;
+    margin: 0 auto 3.75rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
-.cards > ul {
+.cards>ul {
     display: flex;
     justify-content: center;
     list-style: none;
@@ -26,25 +26,25 @@ main .block.cards {
     padding-inline-start: 0;
 }
 
-.cards > ul > li {
+.cards>ul>li {
     box-sizing: border-box;
     box-shadow: 0 2px 12px 0 rgb(60 70 80 / 20%);
     border: none;
     transition: all 0.15s ease-in-out;
-    height: 80px;
+    height: 5rem;
     width: 100%;
-    min-width: 56px;
+    min-width: 3.5rem;
     padding: 12px 1rem;
     margin: 0 0 1rem;
     align-items: center;
     text-align: left;
 }
 
-.cards > ul > li:hover {
-    box-shadow: 0 4px 16px 0 rgb(60 70 80 / 40%);
+.cards>ul>li:hover {
+    box-shadow: 0 4px 1rem 0 rgb(60 70 80 / 40%);
 }
 
-.cards > ul > li > a.button {
+.cards>ul>li>a.button {
     margin: 0;
     height: 100%;
     color: var(--card-text-color);
@@ -63,17 +63,17 @@ main .block.cards {
     padding: 0;
 }
 
-.cards > ul > li > a {
+.cards>ul>li>a {
     text-decoration: none;
 }
 
-.cards > ul > li > a:hover {
+.cards>ul>li>a:hover {
     text-decoration: none;
     background-color: initial;
 }
 
 .cards .cards-card-body {
-    width: calc(100% - 1rem - 56px);
+    width: calc(100% - 1rem - 3.5rem);
     margin: 0 auto;
     padding-left: 10px;
     padding-right: 10px;
@@ -92,9 +92,9 @@ main .block.cards {
 .cards .cards-card-image {
     margin: 0;
     padding: 0;
-    width: 56px;
-    min-width: 56px;
-    height: 56px;
+    width: 3.5rem;
+    min-width: 3.5rem;
+    height: 3.5rem;
 }
 
 .cards .cards-card-body div {
@@ -102,9 +102,52 @@ main .block.cards {
     margin: 0;
 }
 
-@media screen and (min-width: 62rem)  {
+.section.cards-container:not(a) {
+    margin: 0;
+}
+
+main .block.cards.nolink {
+    margin: 0 auto 2rem;
+}
+
+.cards.nolink>ul>li {
+    display: flex;
+    flex-direction: row;
+    box-shadow: none;
+    width: 100%;
+    margin: 0 0 1.5rem;
+    padding: 0;
+    text-align: left;
+}
+
+.cards.nolink>ul>li:last-child {
+    margin: 0;
+}
+
+.cards.nolink>ul>li:hover {
+    box-shadow: none;
+}
+
+.cards.nolink .cards-card-image {
+    margin: 0;
+    padding: 0;
+    width: 5rem;
+    min-width: 5rem;
+    height: 5rem;
+}
+
+.cards.nolink>ul>li>.cards-card-body>h6 {
+    text-align: left;
+    text-transform: unset;
+}
+
+@media screen and (min-width: 62rem) {
     .section.cards-container {
         margin: 5rem 0;
+    }
+
+    .section.cards-container:not(a) {
+        margin: 0 0 1rem;
     }
 
     main .block.cards {
@@ -112,11 +155,11 @@ main .block.cards {
         padding-right: 0;
     }
 
-    div.cards > ul {
+    div.cards>ul {
         flex-flow: row nowrap;
     }
 
-    .cards > ul > li {
+    .cards>ul>li {
         width: 162px;
         height: 222px;
         padding: 0;
@@ -124,8 +167,8 @@ main .block.cards {
         margin: 0 7px
     }
 
-    .cards > ul > li > a.button {
-        padding: 16px 6px 0;
+    .cards>ul>li>a.button {
+        padding: 1rem 6px 0;
         display: block;
     }
 
@@ -137,30 +180,50 @@ main .block.cards {
 
     .cards .cards-card-image {
         margin: auto;
-        width: 120px;
-        height: 120px;
+        width: 7.5rem;
+        height: 7.5rem;
     }
 
     .cards .cards-card-image img {
         width: 100%;
         height: 100%;
     }
+
+    main .block.cards.nolink {
+        margin: 0;
+    }
+
+    .cards.nolink>ul>li {
+        display: flex;
+        flex-direction: column;
+        box-shadow: none;
+        width: 16.5rem;
+        height: 100%;
+        margin: 0 1.25rem 1rem;
+        padding: 0;
+    }
+
+    .cards.nolink .cards-card-image {
+        margin: auto;
+        width: 7.5rem;
+        height: 7.5rem;
+    }
 }
 
 @media screen and (min-width: 77rem) {
-    .cards > ul > li {
+    .cards>ul>li {
         width: 214px;
         height: 262px;
-        margin: 0 16px;
+        margin: 0 1rem;
     }
 
-    .cards > ul > li > a.button {
+    .cards>ul>li>a.button {
         padding: 20px 0 0;
     }
 
     .cards .cards-card-image {
-        width: 140px;
-        height: 140px;
+        width: 8.75rem;
+        height: 8.75rem;
     }
 
     .cards .cards-card-body {
@@ -168,5 +231,3 @@ main .block.cards {
         font-size: 1rem;
     }
 }
-
-

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -50,6 +50,9 @@ export default function decorate(block) {
   ul.querySelectorAll('img')
     .forEach((img) => img.closest('picture')
       .replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
+  if (ul.querySelector('a') === null) {
+    block.classList.add('nolink');
+  }
   block.textContent = '';
   block.append(ul);
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #146 

Test URLs:
- Before: [https://main--sunstar-engineering--hlxsites.hlx.live/_drafts/automotive/weldshop](https://main--sunstar-engineering--hlxsites.hlx.live/_drafts/automotive/weldshop)
- After: [https://issue-146--sunstar-engineering--hlxsites.hlx.live/_drafts/automotive/weldshop](https://issue-146--sunstar-engineering--hlxsites.hlx.live/_drafts/automotive/weldshop)

- [ ]  If you are adding a new block or a variation to an existing block, has it been added in the [block-inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar-engineering/_drafts/block-inventory.docx?d=w0e883b961c9f4401bae37da23ace83ec&csf=1&web=1&e=KcfAim) ?

To make the look & feel close to About Us area, I made changes to exsiting cards block:
If the author doesn't add card links,
1.  the box shadow won't show by default.
2.  the box shadow won't show when mouse over it. 
<img width="881" alt="image" src="https://github.com/hlxsites/sunstar-engineering/assets/57093988/95fe1072-0bef-4462-b7d4-b490655d9d40">
