### PR TITLE
issue-182 Added pagename in helix-query

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -22,6 +22,9 @@ indices:
       newsdate:
         select: head > meta[name="newsdate"]
         value: attribute(el, "content")
+      pagename:
+        select: head > meta[name="pagename"]
+        value: attribute(el, "content")
       robots:
         select: head > meta[name="robots"]
         value: attribute(el, "content")


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #182 

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/
- After: https://issue-182--sunstar-engineering--hlxsites.hlx.page/

- [ ]  If you are adding a new block or a variation to an existing block, has it been added in the [block-inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar-engineering/_drafts/block-inventory.docx?d=w0e883b961c9f4401bae37da23ace83ec&csf=1&web=1&e=KcfAim) ?
