### PR TITLE
fix: prevent shoehorning of lists within columns

### DIFF
--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -189,13 +189,6 @@ function convertBackgroundImgsToForegroundImgs(sourceNode, targetNode = sourceNo
   // workaround for inability of importer to handle styles
   // with whitespace in the url
   [...bgImgs].forEach((bgImg) => {
-    bgImg.getAttribute('style').split(';').forEach((style) => {
-      const [prop, value] = style.split(':');
-      if (prop === 'background-image') {
-        const withoutSpaces = value.replace(/\s/g, '');
-        bgImg.style.backgroundImage = withoutSpaces;
-      }
-    });
     WebImporter.DOMUtils.replaceBackgroundByImg(bgImg, targetNode);
   });
 }
@@ -212,17 +205,19 @@ function createColumnBlockFromSection(document) {
        * two columns
        * isn't a hero section
        * doesn't have an embed
+       * doesn't have lists
      */
     const heroParent = Array.from(section.parentElement.classList)
       .filter((s) => /hero/.test(s)).length;
     const hasEmbed = !!section.querySelector('.wp-block-embed');
+    const hasLists = !!section.querySelector('ul');
     const contentColumns = Array.from(section.children)
       .filter(
         (el) => (el.tagName === 'DIV'
           || el.tagName === 'FIGURE'
           || el.tagName === 'IMG'),
       );
-    if (!heroParent && !hasEmbed && contentColumns
+    if (!heroParent && !hasEmbed && !hasLists && contentColumns
       && contentColumns.length === 2
       && section.children.length === 2
       && section.querySelectorAll('p').length !== 0) {
@@ -242,7 +237,7 @@ function createColumnBlockFromSection(document) {
 }
 
 /**
- * Creates a column block from a section if it contains two columns _only_
+ * Creates a cards block from a section
  * @param {HTMLDocument} document The document
  */
 function createCardsBlockFromSection(document) {


### PR DESCRIPTION
Fix #194

before:
<img width="736" alt="image" src="https://github.com/hlxsites/sunstar-engineering/assets/13196365/88920327-ee28-440e-a51e-69437a3380d4">


after:
<img width="391" alt="image" src="https://github.com/hlxsites/sunstar-engineering/assets/13196365/0e577142-c75e-4d26-92d1-83b3ad1a0a0d">


Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/
- After: https://column-importer-fix--sunstar-engineering--hlxsites.hlx.page/

- [ ]  If you are adding a new block or a variation to an existing block, has it been added in the [block-inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar-engineering/_drafts/block-inventory.docx?d=w0e883b961c9f4401bae37da23ace83ec&csf=1&web=1&e=KcfAim) ?
