### PR TITLE
column block variants for cropped, reordered and rearranged images

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -51,7 +51,7 @@
   order: 0;
 }
 
-.columns.bottom-image-in-narrow-view > div > .columns-img-col {
+.columns.invert-image-order-in-narrow-view > div > .columns-img-col {
   order: 2;
 }
 
@@ -257,7 +257,7 @@
     flex-basis: 50%;
   }
 
-  .columns.bottom-image-in-narrow-view > div > .columns-img-col {
+  .columns.invert-image-order-in-narrow-view > div > .columns-img-col {
     order: unset;
   }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -76,7 +76,7 @@
   margin-top: 0;
 }
 
-.columns.overlap-image-in-narrow-view > div > div > p {
+.columns.overlap-text-with-image > div > div > p {
   margin-bottom: 2rem;
 }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -2,6 +2,10 @@
   margin: 2rem 0 4rem;
 }
 
+.columns.crop-image {
+  margin-bottom: 0;
+}
+
 .columns > div {
   display: flex;
   align-items: flex-start;
@@ -47,6 +51,14 @@
   order: 0;
 }
 
+.columns.bottom-image-in-narrow-view > div > .columns-img-col {
+  order: 2;
+}
+
+.columns.crop-image img {
+  object-fit: cover;
+}
+
 .columns > div > .columns-img-col img {
   display: block;
 }
@@ -64,8 +76,21 @@
   margin-top: 0;
 }
 
+.columns.overlap-image-in-narrow-view > div > div > p {
+  margin-bottom: 2rem;
+}
+
 .columns > div > div.non-singleton-img {
   margin: 0 1rem;
+}
+
+.columns.crop-image > div {
+  align-items: stretch;
+}
+
+.columns.overlap-image-in-narrow-view > div > div.non-singleton-img {
+  margin-bottom: -5.25rem;
+  z-index: 1;
 }
 
 .columns.collapse > div > div.non-singleton-img {
@@ -95,8 +120,8 @@
 
 .columns.plain-links > div > div,
 .columns.plain-links > div > div > p {
-    font-size: var(--body-font-size-s);
-    margin-left: 0;
+  font-size: var(--body-font-size-s);
+  margin-left: 0;
 }
 
 .columns.plain-links > div > div > p:last-of-type {
@@ -222,10 +247,22 @@
     gap: 3rem;
   }
 
+  .columns > div > .columns-img-col {
+    order: unset;
+  }
+
   .columns > div > div {
     flex: 1;
     order: unset;
     flex-basis: 50%;
+  }
+
+  .columns.bottom-image-in-narrow-view > div > .columns-img-col {
+    order: unset;
+  }
+
+  .columns.overlap-image-in-narrow-view > div > div.non-singleton-img {
+    margin-bottom: unset;
   }
 
   .columns.plain-links > div a {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -88,7 +88,7 @@
   align-items: stretch;
 }
 
-.columns.overlap-image-in-narrow-view > div > div.non-singleton-img {
+.columns.overlap-text-with-image > div > div.non-singleton-img {
   margin-bottom: -5.25rem;
   z-index: 1;
 }
@@ -261,7 +261,7 @@
     order: unset;
   }
 
-  .columns.overlap-image-in-narrow-view > div > div.non-singleton-img {
+  .columns.overlap-text-with-image > div > div.non-singleton-img {
     margin-bottom: unset;
   }
 


### PR DESCRIPTION
Fix #57

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about
- After: https://i57-crop-image-column--sunstar-engineering--hlxsites.hlx.page/_drafts/ashishc/about

- [x] adding a new block or a variation to an existing block, has been added in the [block-inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar-engineering/_drafts/block-inventory.docx?d=w0e883b961c9f4401bae37da23ace83ec&csf=1&web=1&e=KcfAim)

----
* block representation in docx
![image](https://github.com/hlxsites/sunstar-engineering/assets/13196365/ab466b76-265f-4b84-888f-5ac8b1a274f7)

* wide viewport view
![image](https://github.com/hlxsites/sunstar-engineering/assets/13196365/74e46618-1857-4357-9829-f34bd26a5ef3)

* narrow viewport view
![image](https://github.com/hlxsites/sunstar-engineering/assets/13196365/cd3481d6-69e0-4d11-8509-0da452ad3d6e)