### PR TITLE
issue-277 Breadcrumb color changes

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -45,7 +45,7 @@
 }
 
 .breadcrumb-item:last-child {
-  color: var(--transparent-grey-color);
+  color: var(--light-black);
 }
 
 @media (min-width: 62rem) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -54,6 +54,7 @@
   --off-white: #ffffff80;
   --muted-text: #ffffffb3;
   --light-grey: #3C46507F;
+  --light-black: #3C4650;
 
 
   /* fonts */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #277 

Test URLs:
- Before: https://main--sunstar-engineering--hlxsites.hlx.page/automotive/weldshop
- After: https://issue-277--sunstar-engineering--hlxsites.hlx.page/automotive/weldshop

- [ ]  If you are adding a new block or a variation to an existing block, has it been added in the [block-inventory](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/Shared%20Documents/sites/sunstar/sunstar-engineering/_drafts/block-inventory.docx?d=w0e883b961c9f4401bae37da23ace83ec&csf=1&web=1&e=KcfAim) ?
